### PR TITLE
【FIXED】`rails g`コマンドの際にいらないファイルが生成されないようにする #1

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,11 @@ module Blogapp
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
 
+    config.generators do |g|
+      g.assets false
+      g.helper false
+    end
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading


### PR DESCRIPTION
#1

- apprication.rbに`rails g`でhelper.rbと生成しない設定を作成